### PR TITLE
New use type construct

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -49,6 +49,8 @@
    (>= 1.2.0))
   (pp-extended
    (>= 0.0.2))
+  (ppxlib
+   (>= 0.32.2-preview.1))
   (ppx_compare
    (and
     (>= v0.17)

--- a/error-log.opam
+++ b/error-log.opam
@@ -18,6 +18,7 @@ depends: [
   "loc" {>= "0.0.2"}
   "pp" {>= "1.2.0"}
   "pp-extended" {>= "0.0.2"}
+  "ppxlib" {>= "0.32.2-preview.1"}
   "ppx_compare" {>= "v0.17" & < "v0.18"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}
   "ppx_expect" {with-test & >= "v0.17" & < "v0.18"}

--- a/src/dune
+++ b/src/dune
@@ -19,6 +19,8 @@
  (libraries base core.command loc pp pp-extended stdio stdune)
  (preprocess
   (pps
+   ;; First I am checking that the new construct is enough to resolve the coverage issue.
+   ;;   -unused-type-warnings=true
    ppx_compare
    ppx_enumerate
    ppx_hash

--- a/src/error_log.ml
+++ b/src/error_log.ml
@@ -1,48 +1,20 @@
 open! Or_error.Let_syntax
 module Style = Stdune.User_message.Style
 
-(* We do [@@@coverage off] of ppx deriving constructs due to a generated
-   non visitable coverage point:
-
-   {[
-     let _ =
-       fun (_ : t) ->
-       ___bisect_visit___ 0;
-       ()
-     ;;
-   ]}
-
-   This is a known issue with work in progress to fix.
-
-   https://github.com/mbarbin/error-log/issues/1
-*)
-
 module Config = struct
   module Mode = struct
-    module T0 = struct
-      [@@@coverage off]
-
-      type t =
-        | Quiet
-        | Default
-        | Verbose
-        | Debug
-      [@@deriving compare, equal, enumerate, sexp_of]
-    end
-
-    include T0
+    type t =
+      | Quiet
+      | Default
+      | Verbose
+      | Debug
+    [@@deriving compare, equal, enumerate, sexp_of]
 
     let switch t = "--" ^ (Sexp.to_string (sexp_of_t t) |> String.uncapitalize)
   end
 
   module Warn_error = struct
-    module T0 = struct
-      [@@@coverage off]
-
-      type t = bool [@@deriving equal, sexp_of]
-    end
-
-    include T0
+    type t = bool [@@deriving equal, sexp_of]
 
     let switch = "--warn-error"
   end
@@ -126,18 +98,12 @@ let force_am_running_test = ref false
 
 module Message = struct
   module Kind = struct
-    module T0 = struct
-      [@@@coverage off]
-
-      type t =
-        | Error
-        | Warning
-        | Info
-        | Debug
-      [@@deriving equal, enumerate, sexp_of]
-    end
-
-    include T0
+    type t =
+      | Error
+      | Warning
+      | Info
+      | Debug
+    [@@deriving equal, enumerate, sexp_of]
 
     let is_printed t ~(config : Config.t) =
       match (t : t) with


### PR DESCRIPTION
This is an experimental PR to test the change made in https://github.com/ocaml-ppx/ppxlib/pull/495

In particular I would like to confirm that thanks to the change, I can now remove the special coverage off attributes and maintain the same level of coverage.

This is using an unreleased preview packages that combines ongoing changes from ppxlib, published [here](https://github.com/mbarbin/ppxlib/releases/tag/0.32.2-preview.1)